### PR TITLE
Change the address to config file mentioned in Step 6 and 7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,13 +101,13 @@ and save the config file after doing above changes
 
 Launch clipboard publisher by executing::
 
-    python3 anywheredoor/anywheredoor_pub.py --config anywheredoor.conf
+    python3 anywheredoor/anywheredoor_pub.py --config anywheredoor/anywheredoor.conf
 
 **Step 7:**
 
 Execute clipboard subscriber by executing following in new terminal session::
 
-    python3 anywheredoor/anywheredoor_sub.py --config anywheredoor.conf
+    python3 anywheredoor/anywheredoor_sub.py --config anywheredoor/anywheredoor.conf
 
 Repeat step 5-7 on all your machines and keep them running until you want to sync all the clipboards
 


### PR DESCRIPTION
Update the documentation. Step 6 and 7 now use the correct address for `anywheredoor.conf`

resolves #2 